### PR TITLE
Updating README with dependencies for Xubuntu 18.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ mv move-to-next-monitor /somewhere/in/your/$PATH
 ## Dependencies
 
 ```
+# Xubuntu 18.04
+sudo apt install xdotool wmctrl
+
 # Xubuntu 16.04
 sudo apt-get install xdotool
 ```


### PR DESCRIPTION
I've setup the script to work on a fresh install of Xubuntu 18.04 and it seems that _wmctrl_ doesn't come pre-installed.
Just adding a line to the README to let people know to install it as a dependency.