### PR TITLE
Do not move the desktop window

### DIFF
--- a/move-to-next-monitor
+++ b/move-to-next-monitor
@@ -18,6 +18,11 @@ display_width=$(xdotool getdisplaygeometry | cut -d" " -f1)
 display_height=$(xdotool getdisplaygeometry | cut -d" " -f2)
 window_id=$(xdotool getactivewindow)
 
+# Do not move the desktop window!!!
+if [ "$(xdotool getwindowclassname "$window_id")" == 'xfdesktop' ]; then
+    return 0
+fi
+
 # Remember if it was maximized.
 window_horz_maxed=$(xprop -id "$window_id" _NET_WM_STATE | grep '_NET_WM_STATE_MAXIMIZED_HORZ')
 window_vert_maxed=$(xprop -id "$window_id" _NET_WM_STATE | grep '_NET_WM_STATE_MAXIMIZED_VERT')

--- a/move-to-next-monitor
+++ b/move-to-next-monitor
@@ -19,8 +19,8 @@ display_height=$(xdotool getdisplaygeometry | cut -d" " -f2)
 window_id=$(xdotool getactivewindow)
 
 # Do not move the desktop window!!!
-if [ "$(xdotool getwindowclassname "$window_id")" == 'xfdesktop' ]; then
-    return 0
+if [ "$(xdotool getwindowclassname "$window_id")" == 'Xfdesktop' ]; then
+    exit
 fi
 
 # Remember if it was maximized.

--- a/move-to-next-monitor
+++ b/move-to-next-monitor
@@ -19,7 +19,7 @@ display_height=$(xdotool getdisplaygeometry | cut -d" " -f2)
 window_id=$(xdotool getactivewindow)
 
 # Do not move the desktop window!!!
-if [ "$(xdotool getwindowclassname "$window_id")" == 'Xfdesktop' ]; then
+if [ "$(xprop -id "$window_id" WM_CLASS | awk '{print $4}' | cut -d '"' -f2)" == 'Xfdesktop' ]; then
     exit
 fi
 


### PR DESCRIPTION
Currently the script if run on an empty desktop will move the underlying desktop window to other monitor, leaving the previous monitor without root window (so, non-clickable, and any window that would appear there, leaves it's image there and all other not fun and confusing behaviors).

I added a simple if statement that prevents this. This will work only for Xfce, as desktop window class names on other desktop environments will differ, so this might be something to think about, unless we keep this script focused on Xfce, as other DEs might have the feature this script provides built-in (Plasma does if I recall correctly, not sure about GNOME).